### PR TITLE
Pyqt6 migration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,7 @@ include test/plover_template_system-0.1.0-py3-none-any.whl
 include test/plover_template_system-0.2.0-py3-none-any.whl
 include tox.ini
 # UI.
-exclude plover_plugins_manager/gui_qt/*_rc.py
 exclude plover_plugins_manager/gui_qt/*_ui.py
 include plover_plugins_manager/gui_qt/*.ui
-recursive-include plover_plugins_manager/gui_qt/resources *
+include plover_plugins_manager/gui_qt/resources/*.svg
+include plover_plugins_manager/gui_qt/resources/*.qrc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ exclude plover_plugins_manager/gui_qt/*_ui.py
 include plover_plugins_manager/gui_qt/*.ui
 include plover_plugins_manager/gui_qt/resources/*.svg
 include plover_plugins_manager/gui_qt/resources/*.qrc
+include plover_plugins_manager/gui_qt/resources/__init__.py

--- a/plover_plugins_manager/gui_qt/console_widget.py
+++ b/plover_plugins_manager/gui_qt/console_widget.py
@@ -5,12 +5,12 @@ import subprocess
 import sys
 import threading
 
-from PyQt5.QtCore import (
+from PyQt6.QtCore import (
     QVariant,
     pyqtSignal,
 )
-from PyQt5.QtGui import QFontDatabase, QFontMetrics
-from PyQt5.QtWidgets import QWidget
+from PyQt6.QtGui import QFontDatabase, QFontMetrics
+from PyQt6.QtWidgets import QWidget
 
 from plover_plugins_manager.gui_qt.console_widget_ui import Ui_ConsoleWidget
 
@@ -30,7 +30,7 @@ class ConsoleWidget(QWidget, Ui_ConsoleWidget):
         self._popen = subprocess.Popen if popen is None else popen
         self._proc = None
         self._thread = None
-        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
         metrics = QFontMetrics(font)
         self.output.setMinimumSize(80 * metrics.maxWidth(),
                                    24 * metrics.height())

--- a/plover_plugins_manager/gui_qt/info_browser.py
+++ b/plover_plugins_manager/gui_qt/info_browser.py
@@ -1,6 +1,6 @@
-from PyQt5.QtGui import QImage, QTextDocument
-from PyQt5.QtWidgets import QTextBrowser
-from PyQt5.QtCore import QUrl, pyqtSignal
+from PyQt6.QtGui import QImage, QTextDocument
+from PyQt6.QtWidgets import QTextBrowser
+from PyQt6.QtCore import QUrl, pyqtSignal
 
 from plover_plugins_manager.requests import CachedSession, FuturesSession
 
@@ -24,7 +24,7 @@ class InfoBrowser(QTextBrowser):
         else:
             resource = None
         resource_url = resource_url.url()
-        if resource is None and resource_type == QTextDocument.ImageResource \
+        if resource is None and resource_type == QTextDocument.ResourceType.ImageResource \
            and resource_url not in self._images:
             future = self._futures_session.get(resource_url)
             future.add_done_callback(self._request_finished)
@@ -78,7 +78,7 @@ class InfoBrowser(QTextBrowser):
             log.warning('could not load image from %s', url)
             return
         doc = self.document()
-        doc.addResource(QTextDocument.ImageResource, QUrl(url), image)
+        doc.addResource(QTextDocument.ResourceType.ImageResource, QUrl(url), image)
         for frag in self._iter_fragments():
             fmt = frag.charFormat()
             if fmt.isImageFormat() and fmt.toImageFormat().name() == url:

--- a/plover_plugins_manager/gui_qt/manager.py
+++ b/plover_plugins_manager/gui_qt/manager.py
@@ -22,7 +22,7 @@ class PluginsManager(Tool, Ui_PluginsManager):
 
     TITLE = 'Plugins Manager'
     ROLE = 'plugins_manager'
-    ICON = ':/plugins_manager/icon.svg'
+    ICON = ('plover_plugins_manager.gui_qt.resources', ':/icon.svg')
 
     # We use a class instance so the state is persistent
     # accross different executions of the dialog when

--- a/plover_plugins_manager/gui_qt/manager.py
+++ b/plover_plugins_manager/gui_qt/manager.py
@@ -5,8 +5,8 @@ import html
 import os
 import sys
 
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import QDialog, QMessageBox, QTableWidgetItem
 
 from plover.gui_qt.tool import Tool
 
@@ -38,7 +38,7 @@ class PluginsManager(Tool, Ui_PluginsManager):
         self._engine = engine
         self.info = InfoBrowser()
         self.info_frame.layout().addWidget(self.info)
-        self.table.sortByColumn(1, Qt.AscendingOrder)
+        self.table.sortByColumn(1, Qt.SortOrder.AscendingOrder)
         self._packages_updated.connect(self._on_packages_updated)
         if self._packages is None:
             PluginsManager._packages = Registry()
@@ -65,13 +65,13 @@ class PluginsManager(Tool, Ui_PluginsManager):
         for row, state in enumerate(self._packages):
             for column, attr in enumerate('status name version summary'.split()):
                 item = QTableWidgetItem(getattr(state, attr))
-                item.setFlags(item.flags() & ~Qt.ItemIsEditable)
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
                 self.table.setItem(row, column, item)
         self.table.resizeColumnsToContents()
         self.table.setSortingEnabled(True)
 
     def _get_state(self, row):
-        name = self.table.item(row, 1).data(Qt.DisplayRole)
+        name = self.table.item(row, 1).data(Qt.ItemDataRole.DisplayRole)
         return self._packages[name]
 
     def _get_selection(self):
@@ -93,7 +93,7 @@ class PluginsManager(Tool, Ui_PluginsManager):
     @staticmethod
     def _run(args):
         dialog = RunDialog(args, popen=pip)
-        code = dialog.exec_()
+        code = dialog.exec()
         # dialog.destroy()
         return code
 
@@ -157,22 +157,22 @@ class PluginsManager(Tool, Ui_PluginsManager):
     def on_install(self):
         packages = self._get_selection()[0]
         if QMessageBox.warning(
-            self, 'Install ' + ', '.join(packages), 
+            self, 'Install ' + ', '.join(packages),
             'Installing plugins is a <b>security risk</b>. '
             'A plugin can contain virus/malware. '
             'Only install it if you got it from a trusted source.'
             ' Are you sure you want to proceed?'
             ,
-            buttons=QMessageBox.Yes | QMessageBox.No,
-            defaultButton=QMessageBox.No
-        ) != QMessageBox.Yes:
+            buttons=QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            defaultButton=QMessageBox.StandardButton.No
+        ) != QMessageBox.StandardButton.Yes:
             return
         code = self._run(
             ['install'] +
             [self._packages[name].latest.requirement
              for name in packages]
         )
-        if code == QDialog.Accepted:
+        if code == QDialog.DialogCode.Accepted:
             for name in packages:
                 state = self._packages[name]
                 state.current = state.latest
@@ -182,7 +182,7 @@ class PluginsManager(Tool, Ui_PluginsManager):
     def on_uninstall(self):
         packages = self._get_selection()[1]
         code = self._run(['uninstall', '-y'] + packages)
-        if code == QDialog.Accepted:
+        if code == QDialog.DialogCode.Accepted:
             for name in packages:
                 state = self._packages[name]
                 state.current = None
@@ -191,8 +191,8 @@ class PluginsManager(Tool, Ui_PluginsManager):
 
 
 if __name__ == '__main__':
-    from PyQt5.QtWidgets import QApplication
+    from PyQt6.QtWidgets import QApplication
     app = QApplication([])
     dlg = PluginsManager(None)
     dlg.show()
-    app.exec_()
+    app.exec()

--- a/plover_plugins_manager/gui_qt/resources/resources.qrc
+++ b/plover_plugins_manager/gui_qt/resources/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
-  <qresource prefix="/plugins_manager">
+  <qresource>
     <file>icon.svg</file>
   </qresource>
 </RCC>

--- a/plover_plugins_manager/gui_qt/run_dialog.py
+++ b/plover_plugins_manager/gui_qt/run_dialog.py
@@ -1,5 +1,5 @@
 
-from PyQt5.QtWidgets import QDialogButtonBox, QDialog
+from PyQt6.QtWidgets import QDialogButtonBox, QDialog
 
 from plover_plugins_manager.gui_qt.console_widget import ConsoleWidget
 from plover_plugins_manager.gui_qt.run_dialog_ui import Ui_RunDialog
@@ -12,19 +12,19 @@ class RunDialog(QDialog, Ui_RunDialog):
         self.setupUi(self)
         self._console = ConsoleWidget(popen)
         self.layout().replaceWidget(self.console, self._console)
-        self.buttonBox.button(QDialogButtonBox.Close).setHidden(True)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Close).setHidden(True)
         self._console.processFinished.connect(self.on_process_finished)
         self._console.run(run_args)
         self._successful = None
 
     def on_process_finished(self, returncode):
         self._successful = returncode == 0
-        self.buttonBox.button(QDialogButtonBox.Cancel).setHidden(True)
-        self.buttonBox.button(QDialogButtonBox.Close).setHidden(False)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Cancel).setHidden(True)
+        self.buttonBox.button(QDialogButtonBox.StandardButton.Close).setHidden(False)
 
     def reject(self):
         if self._successful is not None:
-            super().done(getattr(QDialog, 'Accepted'
+            super().done(getattr(QDialog.DialogCode, 'Accepted'
                                  if self._successful
                                  else 'Rejected'))
             return
@@ -33,8 +33,8 @@ class RunDialog(QDialog, Ui_RunDialog):
 
 if __name__ == '__main__':
     import sys
-    from PyQt5.QtWidgets import QApplication
+    from PyQt6.QtWidgets import QApplication
     app = QApplication([])
     dlg = RunDialog(sys.argv[1:])
     dlg.show()
-    app.exec_()
+    app.exec()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-	"plover[gui_qt]>=4.0.0.dev10",
+	"plover[gui_qt]@https://github.com/greghope667/plover/archive/pyqt6-migration.zip",
 	"setuptools>=38.2.4",
 	"wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.6
 install_requires =
 	pip
 	pkginfo>=1.4.2
-	plover[gui_qt]>=4.0.0.dev8
+	plover[gui_qt] @ https://github.com/greghope667/plover/archive/pyqt6-migration.zip
 	pygments
 	readme-renderer[md]
 	requests>=2.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,4 @@ cmdclass = {
     'develop': Develop,
 }
 
-setup(cmdclass=cmdclass)
+setup(cmdclass=cmdclass, include_package_data=True)


### PR DESCRIPTION
This is the plugins manager counterpart to https://github.com/openstenoproject/plover/pull/1601. These repositories are mutually dependent so both PRs should be merged together. For CI purposes I've pointed the pip dependencies at each other (i.e. at my own branches), this will need changing back before merging.

The changes needed here are pretty representative of the changes any plugin would need to be PyQt6 compatible. I might make a migration guide if people are interested.